### PR TITLE
Add unit conversions for Duration, MassFraction and add additional Density Convert methods

### DIFF
--- a/Units_Engine/Convert/Density/MicrogramPerLitre.cs
+++ b/Units_Engine/Convert/Density/MicrogramPerLitre.cs
@@ -19,16 +19,13 @@
  * You should have received a copy of the GNU Lesser General Public License     
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
-
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-
 using UN = UnitsNet; //This is to avoid clashes between UnitsNet quantity attributes and BHoM quantity attributes
 using UnitsNet.Units;
-
 using System.ComponentModel;
 using BH.oM.Base.Attributes;
 using BH.oM.Quantities.Attributes;
@@ -37,18 +34,18 @@ namespace BH.Engine.Units
 {
     public static partial class Convert
     {
-        [Description("Convert SI units (kilograms per cubic metre) into micrograms per litre")]
-        [Input("kilogramsPerCubicMetre", "The number of kilograms per cubic metre to convert", typeof(Density))]
-        [Output("microgramsPerLitre", "The number of micrograms per litre")]
+        [Description("Convert SI units (kilograms per cubic metre) into micrograms per litre.")]
+        [Input("kilogramsPerCubicMetre", "The number of kilograms per cubic metre to convert.", typeof(Density))]
+        [Output("microgramsPerLitre", "The number of micrograms per litre.")]
         public static double ToMicrogramPerLitre(this double kilogramsPerCubicMetre)
         {
             UN.QuantityValue qv = kilogramsPerCubicMetre;
             return UN.UnitConverter.Convert(qv, DensityUnit.KilogramPerCubicMeter, DensityUnit.MicrogramPerLiter);
         }
 
-        [Description("Convert micrograms per litre into SI units (kilograms per cubic metre)")]
-        [Input("microgramsPerLitre", "The number of micrograms per litre to convert")]
-        [Output("kilogramsPerCubicMetre", "The number of kilograms per cubic metre", typeof(Density))]
+        [Description("Convert micrograms per litre into SI units (kilograms per cubic metre).")]
+        [Input("microgramsPerLitre", "The number of micrograms per litre to convert.")]
+        [Output("kilogramsPerCubicMetre", "The number of kilograms per cubic metre.", typeof(Density))]
         public static double FromMicrogramPerLitre(this double microgramsPerLitre)
         {
             UN.QuantityValue qv = microgramsPerLitre;
@@ -56,6 +53,3 @@ namespace BH.Engine.Units
         }
     }
 }
-
-
-

--- a/Units_Engine/Convert/Density/MicrogramPerLitre.cs
+++ b/Units_Engine/Convert/Density/MicrogramPerLitre.cs
@@ -37,7 +37,7 @@ namespace BH.Engine.Units
 {
     public static partial class Convert
     {
-        [Description("Convert SI units (kilogram per cubic metre) into micrograms per litre")]
+        [Description("Convert SI units (kilograms per cubic metre) into micrograms per litre")]
         [Input("kilogramsPerCubicMetre", "The number of kilograms per cubic metre to convert", typeof(Density))]
         [Output("microgramsPerLitre", "The number of micrograms per litre")]
         public static double ToMicrogramPerLitre(this double kilogramsPerCubicMetre)

--- a/Units_Engine/Convert/Density/MicrogramPerLitre.cs
+++ b/Units_Engine/Convert/Density/MicrogramPerLitre.cs
@@ -26,16 +26,36 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace BH.oM.Units
+using UN = UnitsNet; //This is to avoid clashes between UnitsNet quantity attributes and BHoM quantity attributes
+using UnitsNet.Units;
+
+using System.ComponentModel;
+using BH.oM.Base.Attributes;
+using BH.oM.Quantities.Attributes;
+
+namespace BH.Engine.Units
 {
-    public enum MassFractionUnit
+    public static partial class Convert
     {
-        Undefined = 0,
-        NanogramPerKilogram = 1,
-        MicrogramPerKilogram = 2,
-        MilligramPerKilogram = 3,
-        CentigramPerKilogram = 4,
-        DecigramPerKilogram = 5,
-        GramPerKilogram = 6
+        [Description("Convert SI units (kilogram per cubic metre) into micrograms per litre")]
+        [Input("kilogramsPerCubicMetre", "The number of kilograms per cubic metre to convert", typeof(Density))]
+        [Output("microgramsPerLitre", "The number of micrograms per litre")]
+        public static double ToMicrogramPerLitre(this double kilogramsPerCubicMetre)
+        {
+            UN.QuantityValue qv = kilogramsPerCubicMetre;
+            return UN.UnitConverter.Convert(qv, DensityUnit.KilogramPerCubicMeter, DensityUnit.MicrogramPerLiter);
+        }
+
+        [Description("Convert micrograms per litre into SI units (kilograms per cubic metre)")]
+        [Input("microgramsPerLitre", "The number of micrograms per litre to convert")]
+        [Output("kilogramsPerCubicMetre", "The number of kilograms per cubic metre", typeof(Density))]
+        public static double FromMicrogramPerLitre(this double microgramsPerLitre)
+        {
+            UN.QuantityValue qv = microgramsPerLitre;
+            return UN.UnitConverter.Convert(qv, DensityUnit.MicrogramPerLiter, DensityUnit.KilogramPerCubicMeter);
+        }
     }
 }
+
+
+

--- a/Units_Engine/Convert/Density/MilligramPerLitre.cs
+++ b/Units_Engine/Convert/Density/MilligramPerLitre.cs
@@ -19,16 +19,13 @@
  * You should have received a copy of the GNU Lesser General Public License     
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
-
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-
 using UN = UnitsNet; //This is to avoid clashes between UnitsNet quantity attributes and BHoM quantity attributes
 using UnitsNet.Units;
-
 using System.ComponentModel;
 using BH.oM.Base.Attributes;
 using BH.oM.Quantities.Attributes;
@@ -37,18 +34,18 @@ namespace BH.Engine.Units
 {
     public static partial class Convert
     {
-        [Description("Convert SI units (kilograms per cubic metre) into milligrams per litre")]
-        [Input("kilogramsPerCubicMetre", "The number of kilograms per cubic metre to convert", typeof(Density))]
-        [Output("milligramsPerLitre", "The number of milligrams per litre")]
+        [Description("Convert SI units (kilograms per cubic metre) into milligrams per litre.")]
+        [Input("kilogramsPerCubicMetre", "The number of kilograms per cubic metre to convert.", typeof(Density))]
+        [Output("milligramsPerLitre", "The number of milligrams per litre.")]
         public static double ToMilligramPerLitre(this double kilogramsPerCubicMetre)
         {
             UN.QuantityValue qv = kilogramsPerCubicMetre;
             return UN.UnitConverter.Convert(qv, DensityUnit.KilogramPerCubicMeter, DensityUnit.MilligramPerLiter);
         }
 
-        [Description("Convert grams per litre into SI units (kilograms per cubic metre)")]
-        [Input("milligramsPerLitre", "The number of milligrams per litre to convert")]
-        [Output("kilogramsPerCubicMetre", "The number of kilograms per cubic metre", typeof(Density))]
+        [Description("Convert grams per litre into SI units (kilograms per cubic metre).")]
+        [Input("milligramsPerLitre", "The number of milligrams per litre to convert.")]
+        [Output("kilogramsPerCubicMetre", "The number of kilograms per cubic metre.", typeof(Density))]
         public static double FromMilligramPerLitre(this double milligramsPerLitre)
         {
             UN.QuantityValue qv = milligramsPerLitre;
@@ -56,6 +53,3 @@ namespace BH.Engine.Units
         }
     }
 }
-
-
-

--- a/Units_Engine/Convert/Density/MilligramPerLitre.cs
+++ b/Units_Engine/Convert/Density/MilligramPerLitre.cs
@@ -37,7 +37,7 @@ namespace BH.Engine.Units
 {
     public static partial class Convert
     {
-        [Description("Convert SI units (kilogram per cubic metre) into milligrams per litre")]
+        [Description("Convert SI units (kilograms per cubic metre) into milligrams per litre")]
         [Input("kilogramsPerCubicMetre", "The number of kilograms per cubic metre to convert", typeof(Density))]
         [Output("milligramsPerLitre", "The number of milligrams per litre")]
         public static double ToMilligramPerLitre(this double kilogramsPerCubicMetre)

--- a/Units_Engine/Convert/Density/MilligramPerLitre.cs
+++ b/Units_Engine/Convert/Density/MilligramPerLitre.cs
@@ -26,16 +26,36 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace BH.oM.Units
+using UN = UnitsNet; //This is to avoid clashes between UnitsNet quantity attributes and BHoM quantity attributes
+using UnitsNet.Units;
+
+using System.ComponentModel;
+using BH.oM.Base.Attributes;
+using BH.oM.Quantities.Attributes;
+
+namespace BH.Engine.Units
 {
-    public enum MassFractionUnit
+    public static partial class Convert
     {
-        Undefined = 0,
-        NanogramPerKilogram = 1,
-        MicrogramPerKilogram = 2,
-        MilligramPerKilogram = 3,
-        CentigramPerKilogram = 4,
-        DecigramPerKilogram = 5,
-        GramPerKilogram = 6
+        [Description("Convert SI units (kilogram per cubic metre) into milligrams per litre")]
+        [Input("kilogramsPerCubicMetre", "The number of kilograms per cubic metre to convert", typeof(Density))]
+        [Output("milligramsPerLitre", "The number of milligrams per litre")]
+        public static double ToMilligramPerLitre(this double kilogramsPerCubicMetre)
+        {
+            UN.QuantityValue qv = kilogramsPerCubicMetre;
+            return UN.UnitConverter.Convert(qv, DensityUnit.KilogramPerCubicMeter, DensityUnit.MilligramPerLiter);
+        }
+
+        [Description("Convert grams per litre into SI units (kilograms per cubic metre)")]
+        [Input("milligramsPerLitre", "The number of milligrams per litre to convert")]
+        [Output("kilogramsPerCubicMetre", "The number of kilograms per cubic metre", typeof(Density))]
+        public static double FromMilligramPerLitre(this double milligramsPerLitre)
+        {
+            UN.QuantityValue qv = milligramsPerLitre;
+            return UN.UnitConverter.Convert(qv, DensityUnit.MilligramPerLiter, DensityUnit.KilogramPerCubicMeter);
+        }
     }
 }
+
+
+

--- a/Units_Engine/Convert/Duration/Duration.cs
+++ b/Units_Engine/Convert/Duration/Duration.cs
@@ -42,10 +42,10 @@ namespace BH.Engine.Units
         /**** Public Methods                            ****/
         /***************************************************/
 
-        [Description("Convert a duration into SI units (Seconds).")]
+        [Description("Convert a duration into SI units (seconds).")]
         [Input("duration", "The quantity to convert.")]
         [Input("unit", "The unit in which the quantity is defined. This can be a string, or you can use the BHoM Enum DurationUnit.")]
-        [Output("Second", "The equivalent number of Second.")]
+        [Output("second", "The equivalent number of seconds.")]
         public static double FromDuration(this double duration, object unit)
         {
             if (Double.IsNaN(duration) || Double.IsInfinity(duration))

--- a/Units_Engine/Convert/Duration/Duration.cs
+++ b/Units_Engine/Convert/Duration/Duration.cs
@@ -1,0 +1,130 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2023, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using UN = UnitsNet; //This is to avoid clashes between UnitsNet quantity attributes and BHoM quantity attributes
+using UNU = UnitsNet.Units;
+
+using System.ComponentModel;
+using BH.oM.Base.Attributes;
+using BH.oM.Units;
+using BH.Engine.Base;
+
+namespace BH.Engine.Units
+{
+    public static partial class Convert
+    {
+        /***************************************************/
+        /**** Public Methods                            ****/
+        /***************************************************/
+
+        [Description("Convert a duration into SI units (Seconds).")]
+        [Input("duration", "The quantity to convert.")]
+        [Input("unit", "The unit in which the quantity is defined. This can be a string, or you can use the BHoM Enum DurationUnit.")]
+        [Output("Second", "The equivalent number of Second.")]
+        public static double FromDuration(this double duration, object unit)
+        {
+            if (Double.IsNaN(duration) || Double.IsInfinity(duration))
+            {
+                Compute.RecordError("Quantity is not a real number.");
+                return double.NaN;
+            }
+
+            UN.QuantityValue qv = duration;
+            UNU.DurationUnit unitSI = UNU.DurationUnit.Second;
+            UNU.DurationUnit unUnit = ToDurationUnit(unit);
+
+            if (unUnit != UNU.DurationUnit.Undefined)
+                return UN.UnitConverter.Convert(qv, unUnit, unitSI);
+
+            Compute.RecordError("Unit was undefined. Please use the appropriate BHoM Units Enum.");
+            return double.NaN;
+        }
+
+        /***************************************************/
+
+        [Description("Convert SI units (seconds) into another duration unit.")]
+        [Input("Second", "The number of seconds to convert.")]
+        [Input("unit", "The unit to convert to. This can be a string, or you can use the BHoM Enum DurationUnit.")]
+        [Output("duration", "The equivalent quantity defined in the specified unit.")]
+        public static double ToDuration(this double second, object unit)
+        {
+            if (Double.IsNaN(second) || Double.IsInfinity(second))
+            {
+                Compute.RecordError("Quantity is not a real number.");
+                return double.NaN;
+            }
+
+            UN.QuantityValue qv = second;
+            UNU.DurationUnit unitSI = UNU.DurationUnit.Second;
+            UNU.DurationUnit unUnit = ToDurationUnit(unit);
+
+            if (unUnit != UNU.DurationUnit.Undefined)
+                return UN.UnitConverter.Convert(qv, unitSI, unUnit);
+
+            Compute.RecordError("Unit was undefined. Please use the appropriate BHoM Units Enum.");
+            return double.NaN;
+        }
+
+        /***************************************************/
+        /**** Private Methods                           ****/
+        /***************************************************/
+
+        private static UNU.DurationUnit ToDurationUnit(object unit)
+        {
+            if (unit == null || unit.ToString() == null)
+                return UNU.DurationUnit.Undefined;
+
+            if (unit.GetType() == typeof(string))
+            {
+                DurationUnit unitEnum;
+                if (Enum.TryParse<DurationUnit>(unit.ToString(), out unitEnum))
+                    unit = unitEnum;
+                else
+                    unit = unit.ToString().ToLower();
+            }
+
+            switch (unit)
+            {
+                case DurationUnit.Millisecond:
+                    return UNU.DurationUnit.Millisecond;
+                case DurationUnit.Second:
+                    return UNU.DurationUnit.Second;
+                case DurationUnit.Minute:
+                    return UNU.DurationUnit.Minute;
+                case DurationUnit.Hour:
+                    return UNU.DurationUnit.Hour;
+                case DurationUnit.Undefined:
+                default:
+                    return UNU.DurationUnit.Undefined;
+            }
+        }
+    }
+}
+
+
+

--- a/Units_Engine/Convert/Duration/Duration.cs
+++ b/Units_Engine/Convert/Duration/Duration.cs
@@ -38,6 +38,7 @@ namespace BH.Engine.Units
         /***************************************************/
         /**** Public Methods                            ****/
         /***************************************************/
+
         [Description("Convert a duration into SI units (seconds).")]
         [Input("duration", "The quantity to convert.")]
         [Input("unit", "The unit in which the quantity is defined. This can be a string, or you can use the BHoM Enum DurationUnit.")]
@@ -60,8 +61,9 @@ namespace BH.Engine.Units
         }
 
         /***************************************************/
+
         [Description("Convert SI units (seconds) into another duration unit.")]
-        [Input("Second", "The number of seconds to convert.")]
+        [Input("second", "The number of seconds to convert.")]
         [Input("unit", "The unit to convert to. This can be a string, or you can use the BHoM Enum DurationUnit.")]
         [Output("duration", "The equivalent quantity defined in the specified unit.")]
         public static double ToDuration(this double second, object unit)
@@ -84,6 +86,7 @@ namespace BH.Engine.Units
         /***************************************************/
         /**** Private Methods                           ****/
         /***************************************************/
+
         private static UNU.DurationUnit ToDurationUnit(object unit)
         {
             if (unit == null || unit.ToString() == null)

--- a/Units_Engine/Convert/Duration/Duration.cs
+++ b/Units_Engine/Convert/Duration/Duration.cs
@@ -19,16 +19,13 @@
  * You should have received a copy of the GNU Lesser General Public License     
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
-
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-
 using UN = UnitsNet; //This is to avoid clashes between UnitsNet quantity attributes and BHoM quantity attributes
 using UNU = UnitsNet.Units;
-
 using System.ComponentModel;
 using BH.oM.Base.Attributes;
 using BH.oM.Units;
@@ -41,7 +38,6 @@ namespace BH.Engine.Units
         /***************************************************/
         /**** Public Methods                            ****/
         /***************************************************/
-
         [Description("Convert a duration into SI units (seconds).")]
         [Input("duration", "The quantity to convert.")]
         [Input("unit", "The unit in which the quantity is defined. This can be a string, or you can use the BHoM Enum DurationUnit.")]
@@ -57,16 +53,13 @@ namespace BH.Engine.Units
             UN.QuantityValue qv = duration;
             UNU.DurationUnit unitSI = UNU.DurationUnit.Second;
             UNU.DurationUnit unUnit = ToDurationUnit(unit);
-
             if (unUnit != UNU.DurationUnit.Undefined)
                 return UN.UnitConverter.Convert(qv, unUnit, unitSI);
-
             Compute.RecordError("Unit was undefined. Please use the appropriate BHoM Units Enum.");
             return double.NaN;
         }
 
         /***************************************************/
-
         [Description("Convert SI units (seconds) into another duration unit.")]
         [Input("Second", "The number of seconds to convert.")]
         [Input("unit", "The unit to convert to. This can be a string, or you can use the BHoM Enum DurationUnit.")]
@@ -82,10 +75,8 @@ namespace BH.Engine.Units
             UN.QuantityValue qv = second;
             UNU.DurationUnit unitSI = UNU.DurationUnit.Second;
             UNU.DurationUnit unUnit = ToDurationUnit(unit);
-
             if (unUnit != UNU.DurationUnit.Undefined)
                 return UN.UnitConverter.Convert(qv, unitSI, unUnit);
-
             Compute.RecordError("Unit was undefined. Please use the appropriate BHoM Units Enum.");
             return double.NaN;
         }
@@ -93,12 +84,10 @@ namespace BH.Engine.Units
         /***************************************************/
         /**** Private Methods                           ****/
         /***************************************************/
-
         private static UNU.DurationUnit ToDurationUnit(object unit)
         {
             if (unit == null || unit.ToString() == null)
                 return UNU.DurationUnit.Undefined;
-
             if (unit.GetType() == typeof(string))
             {
                 DurationUnit unitEnum;
@@ -125,6 +114,3 @@ namespace BH.Engine.Units
         }
     }
 }
-
-
-

--- a/Units_Engine/Convert/Duration/Hour.cs
+++ b/Units_Engine/Convert/Duration/Hour.cs
@@ -26,16 +26,37 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace BH.oM.Units
+using UN = UnitsNet; //This is to avoid clashes between UnitsNet quantity attributes and BHoM quantity attributes
+using UnitsNet.Units;
+
+using System.ComponentModel;
+using BH.oM.Base.Attributes;
+using BH.oM.Quantities.Attributes;
+using UnitsNet;
+
+namespace BH.Engine.Units
 {
-    public enum MassFractionUnit
+    public static partial class Convert
     {
-        Undefined = 0,
-        NanogramPerKilogram = 1,
-        MicrogramPerKilogram = 2,
-        MilligramPerKilogram = 3,
-        CentigramPerKilogram = 4,
-        DecigramPerKilogram = 5,
-        GramPerKilogram = 6
+        [Description("Convert SI units (second) into hour")]
+        [Input("second", "The number of second to convert", typeof(Duration))]
+        [Output("hour", "The number of hour")]
+        public static double ToHour(this double second)
+        {
+            UN.QuantityValue qv = second;
+            return UN.UnitConverter.Convert(qv, DurationUnit.Second, DurationUnit.Hour);
+        }
+
+        [Description("Convert minute into SI units (second)")]
+        [Input("hour", "The number of hour to convert")]
+        [Output("second", "The number of second to convert", typeof(Duration))]
+        public static double FromHour(this double hour)
+        {
+            UN.QuantityValue qv = hour;
+            return UN.UnitConverter.Convert(qv, DurationUnit.Hour, DurationUnit.Second);
+        }
     }
 }
+
+
+

--- a/Units_Engine/Convert/Duration/Hour.cs
+++ b/Units_Engine/Convert/Duration/Hour.cs
@@ -19,16 +19,13 @@
  * You should have received a copy of the GNU Lesser General Public License     
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
-
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-
 using UN = UnitsNet; //This is to avoid clashes between UnitsNet quantity attributes and BHoM quantity attributes
 using UnitsNet.Units;
-
 using System.ComponentModel;
 using BH.oM.Base.Attributes;
 using BH.oM.Quantities.Attributes;
@@ -38,18 +35,18 @@ namespace BH.Engine.Units
 {
     public static partial class Convert
     {
-        [Description("Convert SI units (seconds) into hours")]
-        [Input("second", "The number of seconds to convert", typeof(Duration))]
-        [Output("hours", "The number of hours")]
+        [Description("Convert SI units (seconds) into hours.")]
+        [Input("second", "The number of seconds to convert.", typeof(Duration))]
+        [Output("hours", "The number of hours.")]
         public static double ToHour(this double seconds)
         {
             UN.QuantityValue qv = seconds;
             return UN.UnitConverter.Convert(qv, DurationUnit.Second, DurationUnit.Hour);
         }
 
-        [Description("Convert hours into SI units (seconds)")]
-        [Input("hour", "The number of hours to convert")]
-        [Output("seconds", "The number of seconds", typeof(Duration))]
+        [Description("Convert hours into SI units (seconds).")]
+        [Input("hour", "The number of hours to convert.")]
+        [Output("seconds", "The number of seconds.", typeof(Duration))]
         public static double FromHour(this double hours)
         {
             UN.QuantityValue qv = hours;
@@ -57,6 +54,3 @@ namespace BH.Engine.Units
         }
     }
 }
-
-
-

--- a/Units_Engine/Convert/Duration/Hour.cs
+++ b/Units_Engine/Convert/Duration/Hour.cs
@@ -38,21 +38,21 @@ namespace BH.Engine.Units
 {
     public static partial class Convert
     {
-        [Description("Convert SI units (second) into hour")]
-        [Input("second", "The number of second to convert", typeof(Duration))]
-        [Output("hour", "The number of hour")]
-        public static double ToHour(this double second)
+        [Description("Convert SI units (seconds) into hours")]
+        [Input("second", "The number of seconds to convert", typeof(Duration))]
+        [Output("hours", "The number of hours")]
+        public static double ToHour(this double seconds)
         {
-            UN.QuantityValue qv = second;
+            UN.QuantityValue qv = seconds;
             return UN.UnitConverter.Convert(qv, DurationUnit.Second, DurationUnit.Hour);
         }
 
-        [Description("Convert minute into SI units (second)")]
-        [Input("hour", "The number of hour to convert")]
-        [Output("second", "The number of second to convert", typeof(Duration))]
-        public static double FromHour(this double hour)
+        [Description("Convert hours into SI units (seconds)")]
+        [Input("hour", "The number of hours to convert")]
+        [Output("seconds", "The number of seconds", typeof(Duration))]
+        public static double FromHour(this double hours)
         {
-            UN.QuantityValue qv = hour;
+            UN.QuantityValue qv = hours;
             return UN.UnitConverter.Convert(qv, DurationUnit.Hour, DurationUnit.Second);
         }
     }

--- a/Units_Engine/Convert/Duration/Hour.cs
+++ b/Units_Engine/Convert/Duration/Hour.cs
@@ -36,7 +36,7 @@ namespace BH.Engine.Units
     public static partial class Convert
     {
         [Description("Convert SI units (seconds) into hours.")]
-        [Input("second", "The number of seconds to convert.", typeof(Duration))]
+        [Input("seconds", "The number of seconds to convert.", typeof(Duration))]
         [Output("hours", "The number of hours.")]
         public static double ToHour(this double seconds)
         {
@@ -44,8 +44,10 @@ namespace BH.Engine.Units
             return UN.UnitConverter.Convert(qv, DurationUnit.Second, DurationUnit.Hour);
         }
 
+        /***************************************************/
+
         [Description("Convert hours into SI units (seconds).")]
-        [Input("hour", "The number of hours to convert.")]
+        [Input("hours", "The number of hours to convert.")]
         [Output("seconds", "The number of seconds.", typeof(Duration))]
         public static double FromHour(this double hours)
         {

--- a/Units_Engine/Convert/Duration/Millisecond.cs
+++ b/Units_Engine/Convert/Duration/Millisecond.cs
@@ -49,7 +49,7 @@ namespace BH.Engine.Units
         [Output("seconds", "The number of seconds to convert.", typeof(Duration))]
         public static double FromMillisecond(this double milliseconds)
         {
-            UN.QuantityValue qv = millisecond;
+            UN.QuantityValue qv = milliseconds;
             return UN.UnitConverter.Convert(qv, DurationUnit.Millisecond, DurationUnit.Second);
         }
     }

--- a/Units_Engine/Convert/Duration/Millisecond.cs
+++ b/Units_Engine/Convert/Duration/Millisecond.cs
@@ -38,19 +38,19 @@ namespace BH.Engine.Units
 {
     public static partial class Convert
     {
-        [Description("Convert SI units (second) into millisecond")]
-        [Input("second", "The number of second to convert", typeof(Duration))]
-        [Output("millisecond", "The number of millisecond")]
-        public static double ToMillisecond(this double second)
+        [Description("Convert SI units (seconds) into milliseconds")]
+        [Input("seconds", "The number of seconds to convert", typeof(Duration))]
+        [Output("milliseconds", "The number of milliseconds")]
+        public static double ToMillisecond(this double seconds)
         {
-            UN.QuantityValue qv = second;
+            UN.QuantityValue qv = seconds;
             return UN.UnitConverter.Convert(qv, DurationUnit.Second, DurationUnit.Millisecond);
         }
 
-        [Description("Convert millisecond into SI units (second)")]
-        [Input("millisecond", "The number of millisecond to convert")]
-        [Output("second", "The number of second to convert", typeof(Duration))]
-        public static double FromMillisecond(this double millisecond)
+        [Description("Convert milliseconds into SI units (seconds)")]
+        [Input("milliseconds", "The number of milliseconds to convert")]
+        [Output("seconds", "The number of seconds to convert", typeof(Duration))]
+        public static double FromMillisecond(this double milliseconds)
         {
             UN.QuantityValue qv = millisecond;
             return UN.UnitConverter.Convert(qv, DurationUnit.Millisecond, DurationUnit.Second);

--- a/Units_Engine/Convert/Duration/Millisecond.cs
+++ b/Units_Engine/Convert/Duration/Millisecond.cs
@@ -26,16 +26,37 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace BH.oM.Units
+using UN = UnitsNet; //This is to avoid clashes between UnitsNet quantity attributes and BHoM quantity attributes
+using UnitsNet.Units;
+
+using System.ComponentModel;
+using BH.oM.Base.Attributes;
+using BH.oM.Quantities.Attributes;
+using UnitsNet;
+
+namespace BH.Engine.Units
 {
-    public enum MassFractionUnit
+    public static partial class Convert
     {
-        Undefined = 0,
-        NanogramPerKilogram = 1,
-        MicrogramPerKilogram = 2,
-        MilligramPerKilogram = 3,
-        CentigramPerKilogram = 4,
-        DecigramPerKilogram = 5,
-        GramPerKilogram = 6
+        [Description("Convert SI units (second) into millisecond")]
+        [Input("second", "The number of second to convert", typeof(Duration))]
+        [Output("millisecond", "The number of millisecond")]
+        public static double ToMillisecond(this double second)
+        {
+            UN.QuantityValue qv = second;
+            return UN.UnitConverter.Convert(qv, DurationUnit.Second, DurationUnit.Millisecond);
+        }
+
+        [Description("Convert millisecond into SI units (second)")]
+        [Input("millisecond", "The number of millisecond to convert")]
+        [Output("second", "The number of second to convert", typeof(Duration))]
+        public static double FromMillisecond(this double millisecond)
+        {
+            UN.QuantityValue qv = millisecond;
+            return UN.UnitConverter.Convert(qv, DurationUnit.Millisecond, DurationUnit.Second);
+        }
     }
 }
+
+
+

--- a/Units_Engine/Convert/Duration/Millisecond.cs
+++ b/Units_Engine/Convert/Duration/Millisecond.cs
@@ -19,16 +19,13 @@
  * You should have received a copy of the GNU Lesser General Public License     
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
-
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-
 using UN = UnitsNet; //This is to avoid clashes between UnitsNet quantity attributes and BHoM quantity attributes
 using UnitsNet.Units;
-
 using System.ComponentModel;
 using BH.oM.Base.Attributes;
 using BH.oM.Quantities.Attributes;
@@ -38,18 +35,18 @@ namespace BH.Engine.Units
 {
     public static partial class Convert
     {
-        [Description("Convert SI units (seconds) into milliseconds")]
-        [Input("seconds", "The number of seconds to convert", typeof(Duration))]
-        [Output("milliseconds", "The number of milliseconds")]
+        [Description("Convert SI units (seconds) into milliseconds.")]
+        [Input("seconds", "The number of seconds to convert.", typeof(Duration))]
+        [Output("milliseconds", "The number of milliseconds.")]
         public static double ToMillisecond(this double seconds)
         {
             UN.QuantityValue qv = seconds;
             return UN.UnitConverter.Convert(qv, DurationUnit.Second, DurationUnit.Millisecond);
         }
 
-        [Description("Convert milliseconds into SI units (seconds)")]
-        [Input("milliseconds", "The number of milliseconds to convert")]
-        [Output("seconds", "The number of seconds to convert", typeof(Duration))]
+        [Description("Convert milliseconds into SI units (seconds).")]
+        [Input("milliseconds", "The number of milliseconds to convert.")]
+        [Output("seconds", "The number of seconds to convert.", typeof(Duration))]
         public static double FromMillisecond(this double milliseconds)
         {
             UN.QuantityValue qv = millisecond;
@@ -57,6 +54,3 @@ namespace BH.Engine.Units
         }
     }
 }
-
-
-

--- a/Units_Engine/Convert/Duration/Minute.cs
+++ b/Units_Engine/Convert/Duration/Minute.cs
@@ -38,21 +38,21 @@ namespace BH.Engine.Units
 {
     public static partial class Convert
     {
-        [Description("Convert SI units (second) into minute")]
-        [Input("second", "The number of second to convert", typeof(Duration))]
-        [Output("minute", "The number of minute")]
-        public static double ToMinute(this double minute)
+        [Description("Convert SI units (seconds) into minutes")]
+        [Input("seconds", "The number of seconds to convert", typeof(Duration))]
+        [Output("minutes", "The number of minutes")]
+        public static double ToMinute(this double seconds)
         {
-            UN.QuantityValue qv = minute;
+            UN.QuantityValue qv = seconds;
             return UN.UnitConverter.Convert(qv, DurationUnit.Second, DurationUnit.Minute);
         }
 
-        [Description("Convert minute into SI units (second)")]
-        [Input("minute", "The number of minute to convert")]
-        [Output("second", "The number of second to convert", typeof(Duration))]
-        public static double FromMinute(this double minute)
+        [Description("Convert minutes into SI units (seconds)")]
+        [Input("minutes", "The number of minutes to convert")]
+        [Output("seconds", "The number of seconds to convert", typeof(Duration))]
+        public static double FromMinute(this double minutes)
         {
-            UN.QuantityValue qv = minute;
+            UN.QuantityValue qv = minutes;
             return UN.UnitConverter.Convert(qv, DurationUnit.Minute, DurationUnit.Second);
         }
     }

--- a/Units_Engine/Convert/Duration/Minute.cs
+++ b/Units_Engine/Convert/Duration/Minute.cs
@@ -26,16 +26,37 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace BH.oM.Units
+using UN = UnitsNet; //This is to avoid clashes between UnitsNet quantity attributes and BHoM quantity attributes
+using UnitsNet.Units;
+
+using System.ComponentModel;
+using BH.oM.Base.Attributes;
+using BH.oM.Quantities.Attributes;
+using UnitsNet;
+
+namespace BH.Engine.Units
 {
-    public enum MassFractionUnit
+    public static partial class Convert
     {
-        Undefined = 0,
-        NanogramPerKilogram = 1,
-        MicrogramPerKilogram = 2,
-        MilligramPerKilogram = 3,
-        CentigramPerKilogram = 4,
-        DecigramPerKilogram = 5,
-        GramPerKilogram = 6
+        [Description("Convert SI units (second) into minute")]
+        [Input("second", "The number of second to convert", typeof(Duration))]
+        [Output("minute", "The number of minute")]
+        public static double ToMinute(this double minute)
+        {
+            UN.QuantityValue qv = minute;
+            return UN.UnitConverter.Convert(qv, DurationUnit.Second, DurationUnit.Minute);
+        }
+
+        [Description("Convert minute into SI units (second)")]
+        [Input("minute", "The number of minute to convert")]
+        [Output("second", "The number of second to convert", typeof(Duration))]
+        public static double FromMinute(this double minute)
+        {
+            UN.QuantityValue qv = minute;
+            return UN.UnitConverter.Convert(qv, DurationUnit.Minute, DurationUnit.Second);
+        }
     }
 }
+
+
+

--- a/Units_Engine/Convert/Duration/Minute.cs
+++ b/Units_Engine/Convert/Duration/Minute.cs
@@ -19,16 +19,13 @@
  * You should have received a copy of the GNU Lesser General Public License     
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
-
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-
 using UN = UnitsNet; //This is to avoid clashes between UnitsNet quantity attributes and BHoM quantity attributes
 using UnitsNet.Units;
-
 using System.ComponentModel;
 using BH.oM.Base.Attributes;
 using BH.oM.Quantities.Attributes;
@@ -38,18 +35,18 @@ namespace BH.Engine.Units
 {
     public static partial class Convert
     {
-        [Description("Convert SI units (seconds) into minutes")]
-        [Input("seconds", "The number of seconds to convert", typeof(Duration))]
-        [Output("minutes", "The number of minutes")]
+        [Description("Convert SI units (seconds) into minutes.")]
+        [Input("seconds", "The number of seconds to convert.", typeof(Duration))]
+        [Output("minutes", "The number of minutes.")]
         public static double ToMinute(this double seconds)
         {
             UN.QuantityValue qv = seconds;
             return UN.UnitConverter.Convert(qv, DurationUnit.Second, DurationUnit.Minute);
         }
 
-        [Description("Convert minutes into SI units (seconds)")]
-        [Input("minutes", "The number of minutes to convert")]
-        [Output("seconds", "The number of seconds to convert", typeof(Duration))]
+        [Description("Convert minutes into SI units (seconds).")]
+        [Input("minutes", "The number of minutes to convert.")]
+        [Output("seconds", "The number of seconds to convert.", typeof(Duration))]
         public static double FromMinute(this double minutes)
         {
             UN.QuantityValue qv = minutes;
@@ -57,6 +54,3 @@ namespace BH.Engine.Units
         }
     }
 }
-
-
-

--- a/Units_Engine/Convert/MassFraction/CentigramPerKilogram.cs
+++ b/Units_Engine/Convert/MassFraction/CentigramPerKilogram.cs
@@ -19,16 +19,13 @@
  * You should have received a copy of the GNU Lesser General Public License     
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
-
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-
 using UN = UnitsNet; //This is to avoid clashes between UnitsNet quantity attributes and BHoM quantity attributes
 using UnitsNet.Units;
-
 using System.ComponentModel;
 using BH.oM.Base.Attributes;
 using BH.oM.Quantities.Attributes;
@@ -37,18 +34,18 @@ namespace BH.Engine.Units
 {
     public static partial class Convert
     {
-        [Description("Convert SI units (kilograms per kilogram) into centigrams per kilogram")]
-        [Input("kilogramsPerKilogram", "The number of kilograms per kilogram to convert", typeof(MassFraction))]
-        [Output("centigramsPerKilogram", "The number of centigrams per kilogram")]
+        [Description("Convert SI units (kilograms per kilogram) into centigrams per kilogram.")]
+        [Input("kilogramsPerKilogram", "The number of kilograms per kilogram to convert.", typeof(MassFraction))]
+        [Output("centigramsPerKilogram", "The number of centigrams per kilogram.")]
         public static double ToCentigramPerKilogram(this double kilogramsPerKilogram)
         {
             UN.QuantityValue qv = kilogramsPerKilogram;
             return UN.UnitConverter.Convert(qv, MassFractionUnit.KilogramPerKilogram, MassFractionUnit.CentigramPerKilogram);
         }
 
-        [Description("Convert centigrams per kilogram into SI units (kilograms per kilogram)")]
-        [Input("centigramsPerKilogram", "The number of centigrams per kilogram to convert")]
-        [Output("kilogramsPerKilogram", "The number of kilograms per kilogram", typeof(MassFraction))]
+        [Description("Convert centigrams per kilogram into SI units (kilograms per kilogram).")]
+        [Input("centigramsPerKilogram", "The number of centigrams per kilogram to convert.")]
+        [Output("kilogramsPerKilogram", "The number of kilograms per kilogram.", typeof(MassFraction))]
         public static double FromCentigramPerKilogram(this double centigramsPerKilogram)
         {
             UN.QuantityValue qv = centigramsPerKilogram;
@@ -56,6 +53,3 @@ namespace BH.Engine.Units
         }
     }
 }
-
-
-

--- a/Units_Engine/Convert/MassFraction/CentigramPerKilogram.cs
+++ b/Units_Engine/Convert/MassFraction/CentigramPerKilogram.cs
@@ -1,0 +1,61 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2023, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using UN = UnitsNet; //This is to avoid clashes between UnitsNet quantity attributes and BHoM quantity attributes
+using UnitsNet.Units;
+
+using System.ComponentModel;
+using BH.oM.Base.Attributes;
+using BH.oM.Quantities.Attributes;
+
+namespace BH.Engine.Units
+{
+    public static partial class Convert
+    {
+        [Description("Convert SI units (kilogram per kilogram) into centigram per kilogram")]
+        [Input("kilogramPerKilogram", "The number of kilograms per kilogram to convert", typeof(MassFraction))]
+        [Output("centigramPerKilogram", "The number of centigrams per kilogram")]
+        public static double ToCentigramPerKilogram(this double kilogramsPerKilogram)
+        {
+            UN.QuantityValue qv = kilogramsPerKilogram;
+            return UN.UnitConverter.Convert(qv, MassFractionUnit.KilogramPerKilogram, MassFractionUnit.CentigramPerKilogram);
+        }
+
+        [Description("Convert centigram per kilogram into SI units (kilogram per kilogram)")]
+        [Input("centigramsPerKilogram", "The number of centigrams per kilogram to convert")]
+        [Output("kilogramsPerKilogram", "The number of kilograms per kilogram", typeof(MassFraction))]
+        public static double FromCentigramPerKilogram(this double centigramsPerKilogram)
+        {
+            UN.QuantityValue qv = centigramsPerKilogram;
+            return UN.UnitConverter.Convert(qv, MassFractionUnit.CentigramPerKilogram, MassFractionUnit.KilogramPerKilogram);
+        }
+    }
+}
+
+
+

--- a/Units_Engine/Convert/MassFraction/CentigramPerKilogram.cs
+++ b/Units_Engine/Convert/MassFraction/CentigramPerKilogram.cs
@@ -37,16 +37,16 @@ namespace BH.Engine.Units
 {
     public static partial class Convert
     {
-        [Description("Convert SI units (kilogram per kilogram) into centigram per kilogram")]
-        [Input("kilogramPerKilogram", "The number of kilograms per kilogram to convert", typeof(MassFraction))]
-        [Output("centigramPerKilogram", "The number of centigrams per kilogram")]
+        [Description("Convert SI units (kilograms per kilogram) into centigrams per kilogram")]
+        [Input("kilogramsPerKilogram", "The number of kilograms per kilogram to convert", typeof(MassFraction))]
+        [Output("centigramsPerKilogram", "The number of centigrams per kilogram")]
         public static double ToCentigramPerKilogram(this double kilogramsPerKilogram)
         {
             UN.QuantityValue qv = kilogramsPerKilogram;
             return UN.UnitConverter.Convert(qv, MassFractionUnit.KilogramPerKilogram, MassFractionUnit.CentigramPerKilogram);
         }
 
-        [Description("Convert centigram per kilogram into SI units (kilogram per kilogram)")]
+        [Description("Convert centigrams per kilogram into SI units (kilograms per kilogram)")]
         [Input("centigramsPerKilogram", "The number of centigrams per kilogram to convert")]
         [Output("kilogramsPerKilogram", "The number of kilograms per kilogram", typeof(MassFraction))]
         public static double FromCentigramPerKilogram(this double centigramsPerKilogram)

--- a/Units_Engine/Convert/MassFraction/DecigramPerKilogram.cs
+++ b/Units_Engine/Convert/MassFraction/DecigramPerKilogram.cs
@@ -37,18 +37,18 @@ namespace BH.Engine.Units
 {
     public static partial class Convert
     {
-        [Description("Convert SI units (kilogram per kilogram) into decigram per kilogram")]
-        [Input("kilogramPerKilogram", "The number of kilograms per kilogram to convert", typeof(MassFraction))]
-        [Output("decigramPerKilogram", "The number of decigrams per kilogram")]
+        [Description("Convert SI units (kilograms per kilogram) into decigrams per kilogram")]
+        [Input("kilogramsPerKilogram", "The number of kilograms per kilogram to convert", typeof(MassFraction))]
+        [Output("decigramsPerKilogram", "The number of decigrams per kilogram")]
         public static double ToDecigramPerKilogram(this double kilogramsPerKilogram)
         {
             UN.QuantityValue qv = kilogramsPerKilogram;
             return UN.UnitConverter.Convert(qv, MassFractionUnit.KilogramPerKilogram, MassFractionUnit.DecigramPerKilogram);
         }
 
-        [Description("Convert decigram per kilogram into SI units (kilogram per kilogram)")]
-        [Input("decigramPerKilogram", "The number of decigrams per kilogram to convert")]
-        [Output("kilogramPerKilogram", "The number of kilogram per kilogram", typeof(MassFraction))]
+        [Description("Convert decigrams per kilogram into SI units (kilograms per kilogram)")]
+        [Input("decigramsPerKilogram", "The number of decigrams per kilogram to convert")]
+        [Output("kilogramsPerKilogram", "The number of kilograms per kilogram", typeof(MassFraction))]
         public static double FromDecigramPerKilogram(this double decigramsPerKilogram)
         {
             UN.QuantityValue qv = decigramsPerKilogram;

--- a/Units_Engine/Convert/MassFraction/DecigramPerKilogram.cs
+++ b/Units_Engine/Convert/MassFraction/DecigramPerKilogram.cs
@@ -19,16 +19,13 @@
  * You should have received a copy of the GNU Lesser General Public License     
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
-
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-
 using UN = UnitsNet; //This is to avoid clashes between UnitsNet quantity attributes and BHoM quantity attributes
 using UnitsNet.Units;
-
 using System.ComponentModel;
 using BH.oM.Base.Attributes;
 using BH.oM.Quantities.Attributes;
@@ -37,18 +34,18 @@ namespace BH.Engine.Units
 {
     public static partial class Convert
     {
-        [Description("Convert SI units (kilograms per kilogram) into decigrams per kilogram")]
-        [Input("kilogramsPerKilogram", "The number of kilograms per kilogram to convert", typeof(MassFraction))]
-        [Output("decigramsPerKilogram", "The number of decigrams per kilogram")]
+        [Description("Convert SI units (kilograms per kilogram) into decigrams per kilogram.")]
+        [Input("kilogramsPerKilogram", "The number of kilograms per kilogram to convert.", typeof(MassFraction))]
+        [Output("decigramsPerKilogram", "The number of decigrams per kilogram.")]
         public static double ToDecigramPerKilogram(this double kilogramsPerKilogram)
         {
             UN.QuantityValue qv = kilogramsPerKilogram;
             return UN.UnitConverter.Convert(qv, MassFractionUnit.KilogramPerKilogram, MassFractionUnit.DecigramPerKilogram);
         }
 
-        [Description("Convert decigrams per kilogram into SI units (kilograms per kilogram)")]
-        [Input("decigramsPerKilogram", "The number of decigrams per kilogram to convert")]
-        [Output("kilogramsPerKilogram", "The number of kilograms per kilogram", typeof(MassFraction))]
+        [Description("Convert decigrams per kilogram into SI units (kilograms per kilogram).")]
+        [Input("decigramsPerKilogram", "The number of decigrams per kilogram to convert.")]
+        [Output("kilogramsPerKilogram", "The number of kilograms per kilogram.", typeof(MassFraction))]
         public static double FromDecigramPerKilogram(this double decigramsPerKilogram)
         {
             UN.QuantityValue qv = decigramsPerKilogram;
@@ -56,6 +53,3 @@ namespace BH.Engine.Units
         }
     }
 }
-
-
-

--- a/Units_Engine/Convert/MassFraction/DecigramPerKilogram.cs
+++ b/Units_Engine/Convert/MassFraction/DecigramPerKilogram.cs
@@ -1,0 +1,61 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2023, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using UN = UnitsNet; //This is to avoid clashes between UnitsNet quantity attributes and BHoM quantity attributes
+using UnitsNet.Units;
+
+using System.ComponentModel;
+using BH.oM.Base.Attributes;
+using BH.oM.Quantities.Attributes;
+
+namespace BH.Engine.Units
+{
+    public static partial class Convert
+    {
+        [Description("Convert SI units (kilogram per kilogram) into decigram per kilogram")]
+        [Input("kilogramPerKilogram", "The number of kilograms per kilogram to convert", typeof(MassFraction))]
+        [Output("decigramPerKilogram", "The number of decigrams per kilogram")]
+        public static double ToDecigramPerKilogram(this double kilogramsPerKilogram)
+        {
+            UN.QuantityValue qv = kilogramsPerKilogram;
+            return UN.UnitConverter.Convert(qv, MassFractionUnit.KilogramPerKilogram, MassFractionUnit.DecigramPerKilogram);
+        }
+
+        [Description("Convert decigram per kilogram into SI units (kilogram per kilogram)")]
+        [Input("decigramPerKilogram", "The number of decigrams per kilogram to convert")]
+        [Output("kilogramPerKilogram", "The number of kilogram per kilogram", typeof(MassFraction))]
+        public static double FromDecigramPerKilogram(this double decigramsPerKilogram)
+        {
+            UN.QuantityValue qv = decigramsPerKilogram;
+            return UN.UnitConverter.Convert(qv, MassFractionUnit.DecigramPerKilogram, MassFractionUnit.KilogramPerKilogram);
+        }
+    }
+}
+
+
+

--- a/Units_Engine/Convert/MassFraction/GramPerKilogram.cs
+++ b/Units_Engine/Convert/MassFraction/GramPerKilogram.cs
@@ -1,0 +1,61 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2023, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using UN = UnitsNet; //This is to avoid clashes between UnitsNet quantity attributes and BHoM quantity attributes
+using UnitsNet.Units;
+
+using System.ComponentModel;
+using BH.oM.Base.Attributes;
+using BH.oM.Quantities.Attributes;
+
+namespace BH.Engine.Units
+{
+    public static partial class Convert
+    {
+        [Description("Convert SI units (kilogram per kilogram) into decigram per kilogram")]
+        [Input("gramPerKilogram", "The number of kilograms per kilogram to convert", typeof(MassFraction))]
+        [Output("gramPerKilogram", "The number of grams per kilogram")]
+        public static double ToGramPerKilogram(this double kilogramsPerKilogram)
+        {
+            UN.QuantityValue qv = kilogramsPerKilogram;
+            return UN.UnitConverter.Convert(qv, MassFractionUnit.KilogramPerKilogram, MassFractionUnit.GramPerKilogram);
+        }
+
+        [Description("Convert gram per kilogram into SI units (kilogram per kilogram)")]
+        [Input("gramPerKilogram", "The number of grams per kilogram to convert")]
+        [Output("kilogramPerKilogram", "The number of kilogram per kilogram", typeof(MassFraction))]
+        public static double FromGramPerKilogram(this double gramsPerKilogram)
+        {
+            UN.QuantityValue qv = gramsPerKilogram;
+            return UN.UnitConverter.Convert(qv, MassFractionUnit.GramPerKilogram, MassFractionUnit.KilogramPerKilogram);
+        }
+    }
+}
+
+
+

--- a/Units_Engine/Convert/MassFraction/GramPerKilogram.cs
+++ b/Units_Engine/Convert/MassFraction/GramPerKilogram.cs
@@ -19,16 +19,13 @@
  * You should have received a copy of the GNU Lesser General Public License     
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
-
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-
 using UN = UnitsNet; //This is to avoid clashes between UnitsNet quantity attributes and BHoM quantity attributes
 using UnitsNet.Units;
-
 using System.ComponentModel;
 using BH.oM.Base.Attributes;
 using BH.oM.Quantities.Attributes;
@@ -37,18 +34,18 @@ namespace BH.Engine.Units
 {
     public static partial class Convert
     {
-        [Description("Convert SI units (kilograms per kilogram) into grams per kilogram")]
-        [Input("kilogramsPerKilogram", "The number of kilograms per kilogram to convert", typeof(MassFraction))]
-        [Output("gramsPerKilogram", "The number of grams per kilogram")]
+        [Description("Convert SI units (kilograms per kilogram) into grams per kilogram.")]
+        [Input("kilogramsPerKilogram", "The number of kilograms per kilogram to convert.", typeof(MassFraction))]
+        [Output("gramsPerKilogram", "The number of grams per kilogram.")]
         public static double ToGramPerKilogram(this double kilogramsPerKilogram)
         {
             UN.QuantityValue qv = kilogramsPerKilogram;
             return UN.UnitConverter.Convert(qv, MassFractionUnit.KilogramPerKilogram, MassFractionUnit.GramPerKilogram);
         }
 
-        [Description("Convert grams per kilogram into SI units (kilograms per kilogram)")]
-        [Input("gramsPerKilogram", "The number of grams per kilogram to convert")]
-        [Output("kilogramsPerKilogram", "The number of kilograms per kilogram", typeof(MassFraction))]
+        [Description("Convert grams per kilogram into SI units (kilograms per kilogram).")]
+        [Input("gramsPerKilogram", "The number of grams per kilogram to convert.")]
+        [Output("kilogramsPerKilogram", "The number of kilograms per kilogram.", typeof(MassFraction))]
         public static double FromGramPerKilogram(this double gramsPerKilogram)
         {
             UN.QuantityValue qv = gramsPerKilogram;
@@ -56,6 +53,3 @@ namespace BH.Engine.Units
         }
     }
 }
-
-
-

--- a/Units_Engine/Convert/MassFraction/GramPerKilogram.cs
+++ b/Units_Engine/Convert/MassFraction/GramPerKilogram.cs
@@ -37,18 +37,18 @@ namespace BH.Engine.Units
 {
     public static partial class Convert
     {
-        [Description("Convert SI units (kilogram per kilogram) into decigram per kilogram")]
-        [Input("gramPerKilogram", "The number of kilograms per kilogram to convert", typeof(MassFraction))]
-        [Output("gramPerKilogram", "The number of grams per kilogram")]
+        [Description("Convert SI units (kilograms per kilogram) into grams per kilogram")]
+        [Input("kilogramsPerKilogram", "The number of kilograms per kilogram to convert", typeof(MassFraction))]
+        [Output("gramsPerKilogram", "The number of grams per kilogram")]
         public static double ToGramPerKilogram(this double kilogramsPerKilogram)
         {
             UN.QuantityValue qv = kilogramsPerKilogram;
             return UN.UnitConverter.Convert(qv, MassFractionUnit.KilogramPerKilogram, MassFractionUnit.GramPerKilogram);
         }
 
-        [Description("Convert gram per kilogram into SI units (kilogram per kilogram)")]
-        [Input("gramPerKilogram", "The number of grams per kilogram to convert")]
-        [Output("kilogramPerKilogram", "The number of kilogram per kilogram", typeof(MassFraction))]
+        [Description("Convert grams per kilogram into SI units (kilograms per kilogram)")]
+        [Input("gramsPerKilogram", "The number of grams per kilogram to convert")]
+        [Output("kilogramsPerKilogram", "The number of kilograms per kilogram", typeof(MassFraction))]
         public static double FromGramPerKilogram(this double gramsPerKilogram)
         {
             UN.QuantityValue qv = gramsPerKilogram;

--- a/Units_Engine/Convert/MassFraction/MassFraction.cs
+++ b/Units_Engine/Convert/MassFraction/MassFraction.cs
@@ -1,0 +1,134 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2023, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using UN = UnitsNet; //This is to avoid clashes between UnitsNet quantity attributes and BHoM quantity attributes
+using UNU = UnitsNet.Units;
+
+using System.ComponentModel;
+using BH.oM.Base.Attributes;
+using BH.oM.Units;
+using BH.Engine.Base;
+
+namespace BH.Engine.Units
+{
+    public static partial class Convert
+    {
+        /***************************************************/
+        /**** Public Methods                            ****/
+        /***************************************************/
+
+        [Description("Convert a mass fraction into SI units (kilogramPerkilogram).")]
+        [Input("massFraction", "The quantity to convert.")]
+        [Input("unit", "The unit in which the quantity is defined. This can be a string, or you can use the BHoM Enum MassFractionUnit.")]
+        [Output("kilogramPerKilogram", "The equivalent number of kilogramPerKilogram.")]
+        public static double FromMassFraction(this double massFraction, object unit)
+        {
+            if (Double.IsNaN(massFraction) || Double.IsInfinity(massFraction))
+            {
+                Compute.RecordError("Quantity is not a real number.");
+                return double.NaN;
+            }
+
+            UN.QuantityValue qv = massFraction;
+            UNU.MassFractionUnit unitSI = UNU.MassFractionUnit.KilogramPerKilogram;
+            UNU.MassFractionUnit unUnit = ToMassFractionUnit(unit);
+
+            if (unUnit != UNU.MassFractionUnit.Undefined)
+                return UN.UnitConverter.Convert(qv, unUnit, unitSI);
+
+            Compute.RecordError("Unit was undefined. Please use the appropriate BHoM Units Enum.");
+            return double.NaN;
+        }
+
+        /***************************************************/
+
+        [Description("Convert SI units (kilogramPerKilogram) into another massFraction unit.")]
+        [Input("kilogramPerKilogram", "The number of kilogramPerKilogram to convert.")]
+        [Input("unit", "The unit to convert to. This can be a string, or you can use the BHoM Enum massFractionUnit.")]
+        [Output("massFraction", "The equivalent quantity defined in the specified unit.")]
+        public static double ToMassFraction(this double kilogramPerKilogram, object unit)
+        {
+            if (Double.IsNaN(kilogramPerKilogram) || Double.IsInfinity(kilogramPerKilogram))
+            {
+                Compute.RecordError("Quantity is not a real number.");
+                return double.NaN;
+            }
+
+            UN.QuantityValue qv = kilogramPerKilogram;
+            UNU.MassFractionUnit unitSI = UNU.MassFractionUnit.KilogramPerKilogram;
+            UNU.MassFractionUnit unUnit = ToMassFractionUnit(unit);
+
+            if (unUnit != UNU.MassFractionUnit.Undefined)
+                return UN.UnitConverter.Convert(qv, unitSI, unUnit);
+
+            Compute.RecordError("Unit was undefined. Please use the appropriate BHoM Units Enum.");
+            return double.NaN;
+        }
+
+        /***************************************************/
+        /**** Private Methods                           ****/
+        /***************************************************/
+
+        private static UNU.MassFractionUnit ToMassFractionUnit(object unit)
+        {
+            if (unit == null || unit.ToString() == null)
+                return UNU.MassFractionUnit.Undefined;
+
+            if (unit.GetType() == typeof(string))
+            {
+                DensityUnit unitEnum;
+                if (Enum.TryParse<DensityUnit>(unit.ToString(), out unitEnum))
+                    unit = unitEnum;
+                else
+                    unit = unit.ToString().ToLower();
+            }
+
+            switch (unit)
+            {
+                case MassFractionUnit.NanogramPerKilogram:
+                    return UNU.MassFractionUnit.NanogramPerKilogram;
+                case MassFractionUnit.MicrogramPerKilogram:
+                    return UNU.MassFractionUnit.MicrogramPerKilogram;
+                case MassFractionUnit.MilligramPerKilogram:
+                    return UNU.MassFractionUnit.MilligramPerKilogram;
+                case MassFractionUnit.CentigramPerKilogram:
+                    return UNU.MassFractionUnit.CentigramPerKilogram;
+                case MassFractionUnit.DecigramPerKilogram:
+                    return UNU.MassFractionUnit.DecigramPerKilogram;
+                case MassFractionUnit.GramPerKilogram:
+                    return UNU.MassFractionUnit.GramPerKilogram;
+                case DensityUnit.Undefined:
+                default:
+                    return UNU.MassFractionUnit.Undefined;
+            }
+        }
+    }
+}
+
+
+

--- a/Units_Engine/Convert/MassFraction/MassFraction.cs
+++ b/Units_Engine/Convert/MassFraction/MassFraction.cs
@@ -19,16 +19,13 @@
  * You should have received a copy of the GNU Lesser General Public License     
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
-
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-
 using UN = UnitsNet; //This is to avoid clashes between UnitsNet quantity attributes and BHoM quantity attributes
 using UNU = UnitsNet.Units;
-
 using System.ComponentModel;
 using BH.oM.Base.Attributes;
 using BH.oM.Units;
@@ -41,7 +38,6 @@ namespace BH.Engine.Units
         /***************************************************/
         /**** Public Methods                            ****/
         /***************************************************/
-
         [Description("Convert a mass fraction into SI units (kilogramsPerkilogram).")]
         [Input("massFraction", "The quantity to convert.")]
         [Input("unit", "The unit in which the quantity is defined. This can be a string, or you can use the BHoM Enum MassFractionUnit.")]
@@ -57,16 +53,13 @@ namespace BH.Engine.Units
             UN.QuantityValue qv = massFraction;
             UNU.MassFractionUnit unitSI = UNU.MassFractionUnit.KilogramPerKilogram;
             UNU.MassFractionUnit unUnit = ToMassFractionUnit(unit);
-
             if (unUnit != UNU.MassFractionUnit.Undefined)
                 return UN.UnitConverter.Convert(qv, unUnit, unitSI);
-
             Compute.RecordError("Unit was undefined. Please use the appropriate BHoM Units Enum.");
             return double.NaN;
         }
 
         /***************************************************/
-
         [Description("Convert SI units (kilogramsPerKilogram) into another massFraction unit.")]
         [Input("kilogramsPerKilogram", "The number of kilogramsPerKilogram to convert.")]
         [Input("unit", "The unit to convert to. This can be a string, or you can use the BHoM Enum massFractionUnit.")]
@@ -82,10 +75,8 @@ namespace BH.Engine.Units
             UN.QuantityValue qv = kilogramsPerKilogram;
             UNU.MassFractionUnit unitSI = UNU.MassFractionUnit.KilogramPerKilogram;
             UNU.MassFractionUnit unUnit = ToMassFractionUnit(unit);
-
             if (unUnit != UNU.MassFractionUnit.Undefined)
                 return UN.UnitConverter.Convert(qv, unitSI, unUnit);
-
             Compute.RecordError("Unit was undefined. Please use the appropriate BHoM Units Enum.");
             return double.NaN;
         }
@@ -93,12 +84,10 @@ namespace BH.Engine.Units
         /***************************************************/
         /**** Private Methods                           ****/
         /***************************************************/
-
         private static UNU.MassFractionUnit ToMassFractionUnit(object unit)
         {
             if (unit == null || unit.ToString() == null)
                 return UNU.MassFractionUnit.Undefined;
-
             if (unit.GetType() == typeof(string))
             {
                 DensityUnit unitEnum;
@@ -129,6 +118,3 @@ namespace BH.Engine.Units
         }
     }
 }
-
-
-

--- a/Units_Engine/Convert/MassFraction/MassFraction.cs
+++ b/Units_Engine/Convert/MassFraction/MassFraction.cs
@@ -42,10 +42,10 @@ namespace BH.Engine.Units
         /**** Public Methods                            ****/
         /***************************************************/
 
-        [Description("Convert a mass fraction into SI units (kilogramPerkilogram).")]
+        [Description("Convert a mass fraction into SI units (kilogramsPerkilogram).")]
         [Input("massFraction", "The quantity to convert.")]
         [Input("unit", "The unit in which the quantity is defined. This can be a string, or you can use the BHoM Enum MassFractionUnit.")]
-        [Output("kilogramPerKilogram", "The equivalent number of kilogramPerKilogram.")]
+        [Output("kilogramsPerKilogram", "The equivalent number of kilogramsPerKilogram.")]
         public static double FromMassFraction(this double massFraction, object unit)
         {
             if (Double.IsNaN(massFraction) || Double.IsInfinity(massFraction))
@@ -67,19 +67,19 @@ namespace BH.Engine.Units
 
         /***************************************************/
 
-        [Description("Convert SI units (kilogramPerKilogram) into another massFraction unit.")]
-        [Input("kilogramPerKilogram", "The number of kilogramPerKilogram to convert.")]
+        [Description("Convert SI units (kilogramsPerKilogram) into another massFraction unit.")]
+        [Input("kilogramsPerKilogram", "The number of kilogramsPerKilogram to convert.")]
         [Input("unit", "The unit to convert to. This can be a string, or you can use the BHoM Enum massFractionUnit.")]
         [Output("massFraction", "The equivalent quantity defined in the specified unit.")]
-        public static double ToMassFraction(this double kilogramPerKilogram, object unit)
+        public static double ToMassFraction(this double kilogramsPerKilogram, object unit)
         {
-            if (Double.IsNaN(kilogramPerKilogram) || Double.IsInfinity(kilogramPerKilogram))
+            if (Double.IsNaN(kilogramsPerKilogram) || Double.IsInfinity(kilogramsPerKilogram))
             {
                 Compute.RecordError("Quantity is not a real number.");
                 return double.NaN;
             }
 
-            UN.QuantityValue qv = kilogramPerKilogram;
+            UN.QuantityValue qv = kilogramsPerKilogram;
             UNU.MassFractionUnit unitSI = UNU.MassFractionUnit.KilogramPerKilogram;
             UNU.MassFractionUnit unUnit = ToMassFractionUnit(unit);
 

--- a/Units_Engine/Convert/MassFraction/MicrogramPerKilogram.cs
+++ b/Units_Engine/Convert/MassFraction/MicrogramPerKilogram.cs
@@ -37,16 +37,16 @@ namespace BH.Engine.Units
 {
     public static partial class Convert
     {
-        [Description("Convert SI units (kilogram per kilogram) into microgram per kilogram")]
-        [Input("kilogramPerKilogram", "The number of kilograms per kilogram to convert", typeof(MassFraction))]
-        [Output("microgramPerKilogram", "The number of micrograms per kilogram")]
+        [Description("Convert SI units (kilograms per kilogram) into micrograms per kilogram")]
+        [Input("kilogramsPerKilogram", "The number of kilograms per kilogram to convert", typeof(MassFraction))]
+        [Output("microgramsPerKilogram", "The number of micrograms per kilogram")]
         public static double ToMicrogramPerKilogram(this double kilogramsPerKilogram)
         {
             UN.QuantityValue qv = kilogramsPerKilogram;
             return UN.UnitConverter.Convert(qv, MassFractionUnit.KilogramPerKilogram, MassFractionUnit.MicrogramPerKilogram);
         }
 
-        [Description("Convert microgram per kilogram into SI units (kilogram per kilogram)")]
+        [Description("Convert micrograms per kilogram into SI units (kilograms per kilogram)")]
         [Input("microgramsPerKilogram", "The number of micrograms per kilogram to convert")]
         [Output("kilogramsPerKilogram", "The number of kilograms per kilogram", typeof(MassFraction))]
         public static double FromMicrogramPerKilogram(this double microgramsPerKilogram)

--- a/Units_Engine/Convert/MassFraction/MicrogramPerKilogram.cs
+++ b/Units_Engine/Convert/MassFraction/MicrogramPerKilogram.cs
@@ -19,16 +19,13 @@
  * You should have received a copy of the GNU Lesser General Public License     
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
-
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-
 using UN = UnitsNet; //This is to avoid clashes between UnitsNet quantity attributes and BHoM quantity attributes
 using UnitsNet.Units;
-
 using System.ComponentModel;
 using BH.oM.Base.Attributes;
 using BH.oM.Quantities.Attributes;
@@ -37,18 +34,18 @@ namespace BH.Engine.Units
 {
     public static partial class Convert
     {
-        [Description("Convert SI units (kilograms per kilogram) into micrograms per kilogram")]
-        [Input("kilogramsPerKilogram", "The number of kilograms per kilogram to convert", typeof(MassFraction))]
-        [Output("microgramsPerKilogram", "The number of micrograms per kilogram")]
+        [Description("Convert SI units (kilograms per kilogram) into micrograms per kilogram.")]
+        [Input("kilogramsPerKilogram", "The number of kilograms per kilogram to convert.", typeof(MassFraction))]
+        [Output("microgramsPerKilogram", "The number of micrograms per kilogram.")]
         public static double ToMicrogramPerKilogram(this double kilogramsPerKilogram)
         {
             UN.QuantityValue qv = kilogramsPerKilogram;
             return UN.UnitConverter.Convert(qv, MassFractionUnit.KilogramPerKilogram, MassFractionUnit.MicrogramPerKilogram);
         }
 
-        [Description("Convert micrograms per kilogram into SI units (kilograms per kilogram)")]
-        [Input("microgramsPerKilogram", "The number of micrograms per kilogram to convert")]
-        [Output("kilogramsPerKilogram", "The number of kilograms per kilogram", typeof(MassFraction))]
+        [Description("Convert micrograms per kilogram into SI units (kilograms per kilogram).")]
+        [Input("microgramsPerKilogram", "The number of micrograms per kilogram to convert.")]
+        [Output("kilogramsPerKilogram", "The number of kilograms per kilogram.", typeof(MassFraction))]
         public static double FromMicrogramPerKilogram(this double microgramsPerKilogram)
         {
             UN.QuantityValue qv = microgramsPerKilogram;
@@ -56,6 +53,3 @@ namespace BH.Engine.Units
         }
     }
 }
-
-
-

--- a/Units_Engine/Convert/MassFraction/MicrogramPerKilogram.cs
+++ b/Units_Engine/Convert/MassFraction/MicrogramPerKilogram.cs
@@ -1,0 +1,61 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2023, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using UN = UnitsNet; //This is to avoid clashes between UnitsNet quantity attributes and BHoM quantity attributes
+using UnitsNet.Units;
+
+using System.ComponentModel;
+using BH.oM.Base.Attributes;
+using BH.oM.Quantities.Attributes;
+
+namespace BH.Engine.Units
+{
+    public static partial class Convert
+    {
+        [Description("Convert SI units (kilogram per kilogram) into microgram per kilogram")]
+        [Input("kilogramPerKilogram", "The number of kilograms per kilogram to convert", typeof(MassFraction))]
+        [Output("microgramPerKilogram", "The number of micrograms per kilogram")]
+        public static double ToMicrogramPerKilogram(this double kilogramsPerKilogram)
+        {
+            UN.QuantityValue qv = kilogramsPerKilogram;
+            return UN.UnitConverter.Convert(qv, MassFractionUnit.KilogramPerKilogram, MassFractionUnit.MicrogramPerKilogram);
+        }
+
+        [Description("Convert microgram per kilogram into SI units (kilogram per kilogram)")]
+        [Input("microgramsPerKilogram", "The number of micrograms per kilogram to convert")]
+        [Output("kilogramsPerKilogram", "The number of kilograms per kilogram", typeof(MassFraction))]
+        public static double FromMicrogramPerKilogram(this double microgramsPerKilogram)
+        {
+            UN.QuantityValue qv = microgramsPerKilogram;
+            return UN.UnitConverter.Convert(qv, MassFractionUnit.MicrogramPerKilogram, MassFractionUnit.KilogramPerKilogram);
+        }
+    }
+}
+
+
+

--- a/Units_Engine/Convert/MassFraction/MilligramPerKilogram.cs
+++ b/Units_Engine/Convert/MassFraction/MilligramPerKilogram.cs
@@ -35,13 +35,15 @@ namespace BH.Engine.Units
     public static partial class Convert
     {
         [Description("Convert SI units (kilograms per kilogram) into milligrams per kilogram.")]
-        [Input("kilogramsPerkilogram", "The number of kilograms per kilogram to convert.", typeof(MassFraction))]
+        [Input("kilogramsPerKilogram", "The number of kilograms per kilogram to convert.", typeof(MassFraction))]
         [Output("milligramsPerkilogram", "The number of millograms per kilogram.")]
         public static double ToMilligramPerKilogram(this double kilogramsPerKilogram)
         {
             UN.QuantityValue qv = kilogramsPerKilogram;
             return UN.UnitConverter.Convert(qv, MassFractionUnit.KilogramPerKilogram, MassFractionUnit.MilligramPerKilogram);
         }
+
+        /***************************************************/
 
         [Description("Convert milligrams per kilogram into SI units (kilograms per kilogram).")]
         [Input("milligramsPerKilogram", "The number of milligrams per kilogram to convert.")]

--- a/Units_Engine/Convert/MassFraction/MilligramPerKilogram.cs
+++ b/Units_Engine/Convert/MassFraction/MilligramPerKilogram.cs
@@ -1,0 +1,61 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2023, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using UN = UnitsNet; //This is to avoid clashes between UnitsNet quantity attributes and BHoM quantity attributes
+using UnitsNet.Units;
+
+using System.ComponentModel;
+using BH.oM.Base.Attributes;
+using BH.oM.Quantities.Attributes;
+
+namespace BH.Engine.Units
+{
+    public static partial class Convert
+    {
+        [Description("Convert SI units (kilogram per kilogram) into milligrams per kilogram")]
+        [Input("kilogramsPerkilogram", "The number of kilograms per kilogram to convert", typeof(MassFraction))]
+        [Output("milligramPerkilogram", "The number of millograms per kilogram")]
+        public static double ToMilligramPerKilogram(this double kilogramsPerKilogram)
+        {
+            UN.QuantityValue qv = kilogramsPerKilogram;
+            return UN.UnitConverter.Convert(qv, MassFractionUnit.KilogramPerKilogram, MassFractionUnit.MilligramPerKilogram);
+        }
+
+        [Description("Convert milligram per kilogram into SI units (kilograms per kilogram)")]
+        [Input("milligramPerKilogram", "The number of milligrams per kilogram to convert")]
+        [Output("kilogramPerKilogram", "The number of kilograms per kilogram", typeof(MassFraction))]
+        public static double FromMilligramPerKilogram(this double milligramsPerKilogram)
+        {
+            UN.QuantityValue qv = milligramsPerKilogram;
+            return UN.UnitConverter.Convert(qv, MassFractionUnit.MilligramPerKilogram, MassFractionUnit.KilogramPerKilogram);
+        }
+    }
+}
+
+
+

--- a/Units_Engine/Convert/MassFraction/MilligramPerKilogram.cs
+++ b/Units_Engine/Convert/MassFraction/MilligramPerKilogram.cs
@@ -37,17 +37,17 @@ namespace BH.Engine.Units
 {
     public static partial class Convert
     {
-        [Description("Convert SI units (kilogram per kilogram) into milligrams per kilogram")]
+        [Description("Convert SI units (kilograms per kilogram) into milligrams per kilogram")]
         [Input("kilogramsPerkilogram", "The number of kilograms per kilogram to convert", typeof(MassFraction))]
-        [Output("milligramPerkilogram", "The number of millograms per kilogram")]
+        [Output("milligramsPerkilogram", "The number of millograms per kilogram")]
         public static double ToMilligramPerKilogram(this double kilogramsPerKilogram)
         {
             UN.QuantityValue qv = kilogramsPerKilogram;
             return UN.UnitConverter.Convert(qv, MassFractionUnit.KilogramPerKilogram, MassFractionUnit.MilligramPerKilogram);
         }
 
-        [Description("Convert milligram per kilogram into SI units (kilograms per kilogram)")]
-        [Input("milligramPerKilogram", "The number of milligrams per kilogram to convert")]
+        [Description("Convert milligrams per kilogram into SI units (kilograms per kilogram)")]
+        [Input("milligramsPerKilogram", "The number of milligrams per kilogram to convert")]
         [Output("kilogramPerKilogram", "The number of kilograms per kilogram", typeof(MassFraction))]
         public static double FromMilligramPerKilogram(this double milligramsPerKilogram)
         {

--- a/Units_Engine/Convert/MassFraction/MilligramPerKilogram.cs
+++ b/Units_Engine/Convert/MassFraction/MilligramPerKilogram.cs
@@ -19,16 +19,13 @@
  * You should have received a copy of the GNU Lesser General Public License     
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
-
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-
 using UN = UnitsNet; //This is to avoid clashes between UnitsNet quantity attributes and BHoM quantity attributes
 using UnitsNet.Units;
-
 using System.ComponentModel;
 using BH.oM.Base.Attributes;
 using BH.oM.Quantities.Attributes;
@@ -37,18 +34,18 @@ namespace BH.Engine.Units
 {
     public static partial class Convert
     {
-        [Description("Convert SI units (kilograms per kilogram) into milligrams per kilogram")]
-        [Input("kilogramsPerkilogram", "The number of kilograms per kilogram to convert", typeof(MassFraction))]
-        [Output("milligramsPerkilogram", "The number of millograms per kilogram")]
+        [Description("Convert SI units (kilograms per kilogram) into milligrams per kilogram.")]
+        [Input("kilogramsPerkilogram", "The number of kilograms per kilogram to convert.", typeof(MassFraction))]
+        [Output("milligramsPerkilogram", "The number of millograms per kilogram.")]
         public static double ToMilligramPerKilogram(this double kilogramsPerKilogram)
         {
             UN.QuantityValue qv = kilogramsPerKilogram;
             return UN.UnitConverter.Convert(qv, MassFractionUnit.KilogramPerKilogram, MassFractionUnit.MilligramPerKilogram);
         }
 
-        [Description("Convert milligrams per kilogram into SI units (kilograms per kilogram)")]
-        [Input("milligramsPerKilogram", "The number of milligrams per kilogram to convert")]
-        [Output("kilogramPerKilogram", "The number of kilograms per kilogram", typeof(MassFraction))]
+        [Description("Convert milligrams per kilogram into SI units (kilograms per kilogram).")]
+        [Input("milligramsPerKilogram", "The number of milligrams per kilogram to convert.")]
+        [Output("kilogramPerKilogram", "The number of kilograms per kilogram.", typeof(MassFraction))]
         public static double FromMilligramPerKilogram(this double milligramsPerKilogram)
         {
             UN.QuantityValue qv = milligramsPerKilogram;
@@ -56,6 +53,3 @@ namespace BH.Engine.Units
         }
     }
 }
-
-
-

--- a/Units_Engine/Convert/MassFraction/NanogramPerKilogram.cs
+++ b/Units_Engine/Convert/MassFraction/NanogramPerKilogram.cs
@@ -37,18 +37,18 @@ namespace BH.Engine.Units
 {
     public static partial class Convert
     {
-        [Description("Convert SI units (kilogram per kilogram) into nanogram per kilogram")]
-        [Input("kilogramPerKilogram", "The number of kilograms per kilogram to convert", typeof(MassFraction))]
-        [Output("nanogramPerKilogram", "The number of nanograms per kilogram")]
+        [Description("Convert SI units (kilograms per kilogram) into nanograms per kilogram")]
+        [Input("kilogramsPerKilogram", "The number of kilograms per kilogram to convert", typeof(MassFraction))]
+        [Output("nanogramsPerKilogram", "The number of nanograms per kilogram")]
         public static double ToNanogramPerKilogram(this double kilogramsPerKilogram)
         {
             UN.QuantityValue qv = kilogramsPerKilogram;
             return UN.UnitConverter.Convert(qv, MassFractionUnit.KilogramPerKilogram, MassFractionUnit.NanogramPerKilogram);
         }
 
-        [Description("Convert nanogram per kilogram into SI units (kilogram per kilogram)")]
-        [Input("nanogramPerKilogram", "The number of nanograms per kilogram to convert")]
-        [Output("kilogramPerKilogram", "The number of kilogram per kilogram", typeof(MassFraction))]
+        [Description("Convert nanograms per kilogram into SI units (kilograms per kilogram)")]
+        [Input("nanogramsPerKilogram", "The number of nanograms per kilogram to convert")]
+        [Output("kilogramsPerKilogram", "The number of kilograms per kilogram", typeof(MassFraction))]
         public static double FromNanogramPerKilogram(this double nanogramsPerKilogram)
         {
             UN.QuantityValue qv = nanogramsPerKilogram;

--- a/Units_Engine/Convert/MassFraction/NanogramPerKilogram.cs
+++ b/Units_Engine/Convert/MassFraction/NanogramPerKilogram.cs
@@ -1,0 +1,61 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2023, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using UN = UnitsNet; //This is to avoid clashes between UnitsNet quantity attributes and BHoM quantity attributes
+using UnitsNet.Units;
+
+using System.ComponentModel;
+using BH.oM.Base.Attributes;
+using BH.oM.Quantities.Attributes;
+
+namespace BH.Engine.Units
+{
+    public static partial class Convert
+    {
+        [Description("Convert SI units (kilogram per kilogram) into nanogram per kilogram")]
+        [Input("kilogramPerKilogram", "The number of kilograms per kilogram to convert", typeof(MassFraction))]
+        [Output("nanogramPerKilogram", "The number of nanograms per kilogram")]
+        public static double ToNanogramPerKilogram(this double kilogramsPerKilogram)
+        {
+            UN.QuantityValue qv = kilogramsPerKilogram;
+            return UN.UnitConverter.Convert(qv, MassFractionUnit.KilogramPerKilogram, MassFractionUnit.NanogramPerKilogram);
+        }
+
+        [Description("Convert nanogram per kilogram into SI units (kilogram per kilogram)")]
+        [Input("nanogramPerKilogram", "The number of nanograms per kilogram to convert")]
+        [Output("kilogramPerKilogram", "The number of kilogram per kilogram", typeof(MassFraction))]
+        public static double FromNanogramPerKilogram(this double nanogramsPerKilogram)
+        {
+            UN.QuantityValue qv = nanogramsPerKilogram;
+            return UN.UnitConverter.Convert(qv, MassFractionUnit.NanogramPerKilogram, MassFractionUnit.KilogramPerKilogram);
+        }
+    }
+}
+
+
+

--- a/Units_Engine/Convert/MassFraction/NanogramPerKilogram.cs
+++ b/Units_Engine/Convert/MassFraction/NanogramPerKilogram.cs
@@ -19,16 +19,13 @@
  * You should have received a copy of the GNU Lesser General Public License     
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
-
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-
 using UN = UnitsNet; //This is to avoid clashes between UnitsNet quantity attributes and BHoM quantity attributes
 using UnitsNet.Units;
-
 using System.ComponentModel;
 using BH.oM.Base.Attributes;
 using BH.oM.Quantities.Attributes;
@@ -37,18 +34,18 @@ namespace BH.Engine.Units
 {
     public static partial class Convert
     {
-        [Description("Convert SI units (kilograms per kilogram) into nanograms per kilogram")]
-        [Input("kilogramsPerKilogram", "The number of kilograms per kilogram to convert", typeof(MassFraction))]
-        [Output("nanogramsPerKilogram", "The number of nanograms per kilogram")]
+        [Description("Convert SI units (kilograms per kilogram) into nanograms per kilogram.")]
+        [Input("kilogramsPerKilogram", "The number of kilograms per kilogram to convert.", typeof(MassFraction))]
+        [Output("nanogramsPerKilogram", "The number of nanograms per kilogram.")]
         public static double ToNanogramPerKilogram(this double kilogramsPerKilogram)
         {
             UN.QuantityValue qv = kilogramsPerKilogram;
             return UN.UnitConverter.Convert(qv, MassFractionUnit.KilogramPerKilogram, MassFractionUnit.NanogramPerKilogram);
         }
 
-        [Description("Convert nanograms per kilogram into SI units (kilograms per kilogram)")]
-        [Input("nanogramsPerKilogram", "The number of nanograms per kilogram to convert")]
-        [Output("kilogramsPerKilogram", "The number of kilograms per kilogram", typeof(MassFraction))]
+        [Description("Convert nanograms per kilogram into SI units (kilograms per kilogram).")]
+        [Input("nanogramsPerKilogram", "The number of nanograms per kilogram to convert.")]
+        [Output("kilogramsPerKilogram", "The number of kilograms per kilogram.", typeof(MassFraction))]
         public static double FromNanogramPerKilogram(this double nanogramsPerKilogram)
         {
             UN.QuantityValue qv = nanogramsPerKilogram;
@@ -56,6 +53,3 @@ namespace BH.Engine.Units
         }
     }
 }
-
-
-

--- a/Units_oM/Enums/Duration.cs
+++ b/Units_oM/Enums/Duration.cs
@@ -28,14 +28,14 @@ using System.Threading.Tasks;
 
 namespace BH.oM.Units
 {
-    public enum MassFractionUnit
+    public enum DurationUnit
     {
         Undefined = 0,
-        NanogramPerKilogram = 1,
-        MicrogramPerKilogram = 2,
-        MilligramPerKilogram = 3,
-        CentigramPerKilogram = 4,
-        DecigramPerKilogram = 5,
-        GramPerKilogram = 6
+        Millisecond = 1,
+        Second = 2,
+        Minute = 3,
+        Hour = 4
     }
 }
+
+

--- a/Units_oM/Enums/Duration.cs
+++ b/Units_oM/Enums/Duration.cs
@@ -19,7 +19,6 @@
  * You should have received a copy of the GNU Lesser General Public License     
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
-
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -37,5 +36,3 @@ namespace BH.oM.Units
         Hour = 4
     }
 }
-
-

--- a/Units_oM/Enums/MassFraction.cs
+++ b/Units_oM/Enums/MassFraction.cs
@@ -31,11 +31,11 @@ namespace BH.oM.Units
     public enum MassFractionUnit
     {
         Undefined = 0,
-        NanogramPerKilogram = 1,
-        MicrogramPerKilogram = 2,
-        MilligramPerKilogram = 3,
-        CentigramPerKilogram = 4,
-        DecigramPerKilogram = 5,
-        GramPerKilogram = 6
+        CentigramPerKilogram = 1,
+        DecigramPerKilogram = 2,
+        GramPerKilogram = 3,
+        MicrogramPerKilogram = 4,
+        MilligramPerKilogram = 5,
+        NanogramPerKilogram = 6
     }
 }

--- a/Units_oM/Enums/MassFraction.cs
+++ b/Units_oM/Enums/MassFraction.cs
@@ -19,7 +19,6 @@
  * You should have received a copy of the GNU Lesser General Public License     
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
-
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/Units_oM/Enums/MassFraction.cs
+++ b/Units_oM/Enums/MassFraction.cs
@@ -1,0 +1,41 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2023, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BH.oM.Units
+{
+    public enum MassFractionUnit
+    {
+        Undefined = 0,
+        NanogramPerKilogram = 1,
+        MicrogramPerKilogram = 2,
+        MilligramPerKilogram = 3,
+        CentigramPerKilogram = 4,
+        DecigramPerKilogram = 5,
+        GramPerKilogram = 6
+    }
+}


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

 ### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->


 ### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

 Closes #97 

 <!-- Add short description of what has been fixed -->


 ### Test files
<!-- Link to test files to validate the proposed changes -->
https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/02_Pull%20Request/BHoM/Localisation_Toolkit/Units_Engine/%2398-Add%20relevant%20engine%20methods%20and%20enum%20associated%20with%20new%20AGS%20object?csf=1&web=1&e=gT9d9K

 ### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- Added `Convert` methods for specific `Density` methods such as `MicrogramPerLitre` and `MilligramPerLitre`;
- Added `Duration` `Convert` methods for `Millisecond`, `Minute` and `Hour`;
- Added `MassFraction` `Convert` methods for `NanogramPerKillogram`, `MicrogramPerKillogram`, `GramPerKilogram`, `CentigramPerKilogram`, `DecigramPerKilogram`;
- Added `eNums` for `MassFraction` and `Duration`.

 ### Additional comments
<!-- As required -->
Mass fraction conversion methods added in this PR. In responds to issue #97 , density conversion is already available, no additional methods needed.