### PR TITLE
Fix the nuspec template file to reference the correct framework

### DIFF
--- a/.ci/BHoMBot/Nuget/BHoM.Interop.Localisation.nuspec
+++ b/.ci/BHoMBot/Nuget/BHoM.Interop.Localisation.nuspec
@@ -15,7 +15,7 @@
     <tags>BHoM interop localisation units aec</tags>
     <title></title>
     <dependencies>
-      <group targetFramework="netstandard2.0.0">
+      <group targetFramework="netstandard2.0">
         <dependency id="NETStandard.Library" version="2.0.3" />
         <dependency id="UnitsNet" version="4.145.0" />
       </group>


### PR DESCRIPTION

 ### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

 Closes #130 

Fairly straightforward. I simply removed the extra `.0` in the target framework. So this should be pretty quick and easy to review.


 ### Test files
<!-- Link to test files to validate the proposed changes -->


